### PR TITLE
#10723 Support `splitDocumentOption` & `assignmentStrategy`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@ Automation tool to get us started using [Datasaur.ai](https://datasaur.ai) API a
 
 ## Quickstart
 
-Before running any Robosaur commands, we need to [generate our OAuth credentials](https://datasaurai.gitbook.io/datasaur/advanced/apis-docs/oauth-2.0#generate-oauth-credentials-menu) and obtain our teamId from the URL.  
+Before running any Robosaur commands, we need to [generate our OAuth credentials](https://datasaurai.gitbook.io/datasaur/advanced/apis-docs/oauth-2.0#generate-oauth-credentials-menu) and obtain our teamId from the URL.
 
 Before running this quickstart, we need to open [quickstart.json](quickstart/config/quickstart.json) and do these two things:
 
@@ -27,7 +27,7 @@ npm run start -- export-projects quickstart/config/quickstart.json
 
 [quickstart.json](quickstart/config/quickstart.json) is a sample configuration file for creating `"TOKEN_BASED"` projects.  
 To create `"ROW_BASED"` projects, we need a slightly different configuration file, an example is provided in [quickstart.row.json](quickstart/config/quickstart.row.json).  
-You can try to create row-based projects using the same commands as above just by changing the configuration files: 
+You can try to create row-based projects using the same commands as above just by changing the configuration files:
 
 ```bash
 npm run start -- create-projects quickstart/config/quickstart.row.json
@@ -83,7 +83,7 @@ Robosaur will try to create a project for each folder inside the `documents.path
   "documents": {
     "source": "local",
     "path": "quickstart/create/documents"
-  },
+  }
 }
 ```
 
@@ -123,7 +123,7 @@ Robosaur will try to export each projects previously created by the `create-proj
 {
   "export": {
     "source": "local",
-    "prefix": "quickstart/export",
+    "prefix": "quickstart/export"
   }
 }
 ```
@@ -136,16 +136,16 @@ This can be set in the `export.statusFilter` inside the config JSON. In `quickst
 ```json
 {
   "export": {
-    "statusFilter": ["COMPLETE"],
+    "statusFilter": ["COMPLETE"]
   }
 }
 ```
 
 ## Stateful execution
 
-For both commands, Robosaur can behave a bit smarter with the help of a JSON statefile.  
+For both commands, Robosaur can behave a bit smarter with the help of a JSON statefile.
 
-In multiple project creation using the `create-projects` command, the statefile can help keeping track which projects have been created previously, and Robosaur will not create the project again if it had been successfully created before.  
+In multiple project creation using the `create-projects` command, the statefile can help keeping track which projects have been created previously, and Robosaur will not create the project again if it had been successfully created before.
 
 In project export using `export-projects`, the JSON statefile is treated as source of truth. Only projects found in the statefile will be checked against the `statusFilter` and exported.  
 Robosaur will also record the project state when it was last exported, and subsequent runs will only export the project if there had been a forward change in the project status
@@ -157,86 +157,89 @@ In this part we will explain each part of the Robosaur config file. We will use 
 ### Script-wide configuration
 
 1. `"datasaur"`  
-  Contains our OAuth `clientId` and `clientSecret`. These credentials are only enabled for Growth and Enterprise plans. For more information, please reach out to [Datasaur](https://datasaur.ai)
+   Contains our OAuth `clientId` and `clientSecret`. These credentials are only enabled for Growth and Enterprise plans. For more information, please reach out to [Datasaur](https://datasaur.ai)
 2. `"projectState"`  
-  Where we want our statefile to be saved. `projectState.path` can be a full or a relative path to a JSON file. For now, keep `source` as `local` for all `source`s.
+   Where we want our statefile to be saved. `projectState.path` can be a full or a relative path to a JSON file. For now, keep `source` as `local` for all `source`s.
 
 ### Per-command configuration
 
 1. Project creation (`create-projects`)
    1. `"documents"`  
-   Where our project folders are located. A bit different from `projectState.path`, `documents.path` should be a folder path - relative or full.
+      Where our project folders are located. A bit different from `projectState.path`, `documents.path` should be a folder path - relative or full.
    2. `"assignment"`  
-   Where our assignment file is located. `assignment.path` is similar to `projectState.path`, it should be a full or relative path pointing to a JSON file.
+      Where our assignment file is located. `assignment.path` is similar to `projectState.path`, it should be a full or relative path pointing to a JSON file.
    3. `"project"`  
-   This is the Datasaur project configuration.  
-   More options can be seen by creating a project via the web UI, and then clicking the `View Script` button.  
-   In general, we want to keep these mostly unchanged, except for `project.teamId` and `project.customScriptId`  
+      This is the Datasaur project configuration.  
+      More options can be seen by creating a project via the web UI, and then clicking the `View Script` button.  
+      In general, we want to keep these mostly unchanged, except for `project.teamId` and `project.customScriptId`  
+       1. `docFileOptions` - Configuration specific for `ROW_BASED` configs. Refer to [`row-based.md`](row-based.md) for more information.
+       2. `splitDocumentOption` - Allows splitting each document to several parts, based on the `strategy` and `number` option. For more information, see <https://datasaurai.gitbook.io/datasaur/basics/workforce-management/split-files>
 2. Project export (`export-projects`)
    1. `"export"`  
-   This changes Robosaur's export behavior.  
-   `export.prefix` is the folder path where Robosaur will save the export result - make sure Robosaur has write permission to the folder.  
-   `export.format` & `export.customScriptId` affects how Datasaur will export our projects. See this [gitbook link](https://datasaurai.gitbook.io/datasaur/advanced/apis-docs/export-project#export-all-files) for more details.
+      This changes Robosaur's export behavior.  
+      `export.prefix` is the folder path where Robosaur will save the export result - make sure Robosaur has write permission to the folder.  
+      `export.format` & `export.customScriptId` affects how Datasaur will export our projects. See this [gitbook link](https://datasaurai.gitbook.io/datasaur/advanced/apis-docs/export-project#export-all-files) for more details.
 
 ### Storage configuration
 
-There are numerous `"source": "local"` in many places, and we said to keep them as-is. For most use cases, creating and exporting projects to and from local storage is the simplest approach. However, Robosaur also supports project creation from files located in S3 buckets and GCS buckets! All we need to do is set the correct credentials, and change the `source` to `s3` or `gcs`. 
+There are numerous `"source": "local"` in many places, and we said to keep them as-is. For most use cases, creating and exporting projects to and from local storage is the simplest approach. However, Robosaur also supports project creation from files located in S3 buckets and GCS buckets! All we need to do is set the correct credentials, and change the `source` to `s3` or `gcs`.
 
-Here are the examples for credentials and other configs:  
+Here are the examples for credentials and other configs:
 
 1. Google Cloud Storage - `config/google-cloud-storage/config.json`
 
-    ```json
-    {
-      "credentials": {
-        "gcs": { "gcsCredentialJson": "config/google-cloud-storage/credential.json" }
-      },
-      "documents": {
-        "source": "gcs",
-        "bucketName": "my-bucket",
-        "prefix": "projects"
-      },
-    }
-    ```
+   ```json
+   {
+     "credentials": {
+       "gcs": { "gcsCredentialJson": "config/google-cloud-storage/credential.json" }
+     },
+     "documents": {
+       "source": "gcs",
+       "bucketName": "my-bucket",
+       "prefix": "projects"
+     }
+   }
+   ```
 
-    To fully use Robosaur with a GCS bucket, we can use the `Storage Object Admin` role.  
-    The specific IAM permissions required are as follows:
-    - storage.objects.list
-    - storage.objects.get
-    - storage.objects.create - to save export results to GCS bucket
-    - storage.objects.delete - used with storage.objects.create to update the statefile
+   To fully use Robosaur with a GCS bucket, we can use the `Storage Object Admin` role.  
+   The specific IAM permissions required are as follows:
+
+   - storage.objects.list
+   - storage.objects.get
+   - storage.objects.create - to save export results to GCS bucket
+   - storage.objects.delete - used with storage.objects.create to update the statefile
 
 2. Amazon S3 Buckets - `config/s3/config.json`
 
-    ```json
-    {  
-      "credentials": {
-        "s3": {
-          "s3Endpoint": "s3.amazonaws.com",
-          "s3Port": 443,
-          "s3AccessKey": "accesskey",
-          "s3SecretKey": "secretkey",
-          "s3UseSSL": true,
-          "s3Region": "bucket-region-or-null",
-        }
-      },
-      "projectState": {
-        "source": "s3",
-        "bucketName": "my-bucket",
-        "path": "path/to/stateFile.json"
-      },
-    }
-    ```
+   ```json
+   {
+     "credentials": {
+       "s3": {
+         "s3Endpoint": "s3.amazonaws.com",
+         "s3Port": 443,
+         "s3AccessKey": "accesskey",
+         "s3SecretKey": "secretkey",
+         "s3UseSSL": true,
+         "s3Region": "bucket-region-or-null"
+       }
+     },
+     "projectState": {
+       "source": "s3",
+       "bucketName": "my-bucket",
+       "path": "path/to/stateFile.json"
+     }
+   }
+   ```
 
-    `s3Region` is an optional parameter, indicating where your S3 bucket is located.  
-    However, we have encountered some cases where we got `S3: Access Denied` error when it is not defined.  
-    We recommend setting this property whenever possible.     
-    Usually, these are identified by access keys starting with `ASIA...`     
+   `s3Region` is an optional parameter, indicating where your S3 bucket is located.  
+   However, we have encountered some cases where we got `S3: Access Denied` error when it is not defined.  
+   We recommend setting this property whenever possible.  
+   Usually, these are identified by access keys starting with `ASIA...`
 
-    To fully use Robosaur with S3 buckets, these are the IAM Roles required:
-    - s3:GetObject
-    - s3:GetObjectAcl
-    - s3:PutObject
-    - s3:PutObjectAcl
-    - s3:DeleteObject
+   To fully use Robosaur with S3 buckets, these are the IAM Roles required:
 
+   - s3:GetObject
+   - s3:GetObjectAcl
+   - s3:PutObject
+   - s3:PutObjectAcl
+   - s3:DeleteObject

--- a/row-based.md
+++ b/row-based.md
@@ -41,7 +41,7 @@ will need 3 headers in `customHeaderColumns` like so:
 
 ## Question Sets
 
-Currently, Datasaur supports one question set per project. Each question set can have up to <?> questions in it.
+Currently, Datasaur supports one question set per project. Each question set can have up to 100 questions in it.
 
 The provided `quickstart.row.json` uses the [question-set.json](quickstart/create/row-based/question-set.json). Inside are a few examples of how we can define our questions.  
 Here are a few examples, along with some explanations:

--- a/src/assignment/assign-all-documents.spec.ts
+++ b/src/assignment/assign-all-documents.spec.ts
@@ -49,7 +49,7 @@ describe(assignAllDocuments.name, () => {
     });
   });
 
-  describe('BY_PARTS split strat', () => {
+  describe('BY_PARTS split strategy', () => {
     beforeAll(() => {
       assignment = {
         labelers: ['l-one@email.com', 'l-two@email.com', 'l-three@email.com'],

--- a/src/assignment/assign-all-documents.spec.ts
+++ b/src/assignment/assign-all-documents.spec.ts
@@ -1,0 +1,105 @@
+import { Document } from '../documents/interfaces';
+import { assignAllDocuments } from './assign-all-documents';
+import * as ConfigModule from '../config/config';
+import { AssignmentConfig, DocumentAssignment } from './interfaces';
+import { Config, SplitDocumentStrategy } from '../config/interfaces';
+
+describe(assignAllDocuments.name, () => {
+  let assignment: AssignmentConfig;
+  let documents: Document[];
+
+  beforeEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('no split strategy', () => {
+    beforeAll(() => {
+      assignment = {
+        labelers: ['l-one@email.com', 'l-two@email.com', 'l-three@email.com'],
+        reviewers: ['r-one@email.com', 'r-two@email.com'],
+      };
+
+      documents = [
+        { fileName: 'dummy-1' },
+        { fileName: 'dummy-2' },
+        { fileName: 'dummy-3' },
+        { fileName: 'dummy-4' },
+        { fileName: 'dummy-4' },
+      ] as Document[];
+    });
+
+    it('all team members should have the same number of documents assigned', () => {
+      jest
+        .spyOn(ConfigModule, 'getConfig')
+        .mockName('mockGetConfig')
+        .mockImplementation(() => {
+          return {
+            assignment: {
+              strategy: 'ALL',
+            },
+            project: {
+              projectSettings: {
+                consensus: 1,
+              },
+            },
+          } as Config;
+        });
+      const actual = assignAllDocuments(assignment, documents);
+      expect(checkActualHaveSameDocumentLength(actual)).toEqual(true);
+    });
+  });
+
+  describe('BY_PARTS split strat', () => {
+    beforeAll(() => {
+      assignment = {
+        labelers: ['l-one@email.com', 'l-two@email.com', 'l-three@email.com'],
+        reviewers: ['r-one@email.com', 'r-two@email.com'],
+      };
+
+      documents = [{ fileName: 'dummy-1' }, { fileName: 'dummy-2' }] as Document[];
+    });
+    it('all team members should have the same number of documents assigned', () => {
+      const splitDocumentOption = {
+        number: 5,
+        strategy: SplitDocumentStrategy.BY_PARTS,
+      };
+      jest
+        .spyOn(ConfigModule, 'getConfig')
+        .mockName('mockGetConfig')
+        .mockImplementation(() => {
+          return {
+            assignment: {
+              strategy: 'ALL',
+            },
+            project: {
+              splitDocumentOption: splitDocumentOption,
+              projectSettings: {
+                consensus: 1,
+              },
+            },
+          } as Config;
+        });
+
+      const actual = assignAllDocuments(assignment, documents);
+      expect(checkActualHaveSameDocumentLength(actual)).toEqual(true);
+    });
+  });
+});
+
+function checkActualHaveSameDocumentLength(documentAssignments: DocumentAssignment[]) {
+  let length: number | undefined = undefined;
+  for (const documentAssignment of documentAssignments) {
+    if (documentAssignment.documents) {
+      if (length) {
+        if (length != documentAssignment.documents.length) {
+          return false;
+        }
+      } else {
+        length = documentAssignment.documents.length;
+      }
+    } else {
+      console.error('documents was null / undefined');
+    }
+  }
+  return true;
+}

--- a/src/assignment/assign-all-documents.ts
+++ b/src/assignment/assign-all-documents.ts
@@ -1,12 +1,10 @@
 import { Document } from '../documents/interfaces';
+import { getDocumentsWithPart } from './get-documents-with-part';
 import { getRole } from './get-role';
 import { AssignmentConfig, DocumentAssignment } from './interfaces';
 
 export function assignAllDocuments(assignmentPool: AssignmentConfig, documents: Document[]): DocumentAssignment[] {
-  const allDocuments = documents.map((document) => ({
-    fileName: document.fileName,
-    part: 0,
-  }));
+  const allDocuments = getDocumentsWithPart(documents);
 
   const members: Record<string, { isLabeler: boolean; isReviewer: boolean }> = {};
   assignmentPool.labelers.forEach((labeler) => {

--- a/src/assignment/assign-auto-documents.spec.ts
+++ b/src/assignment/assign-auto-documents.spec.ts
@@ -1,0 +1,195 @@
+import * as ConfigModule from '../config/config';
+import { Config, SplitDocumentStrategy } from '../config/interfaces';
+import { Document } from '../documents/interfaces';
+import { assignAutoDocuments } from './assign-auto-documents';
+import { AssignmentConfig, DocumentAssignment } from './interfaces';
+
+describe(assignAutoDocuments.name, () => {
+  let assignment: AssignmentConfig;
+  let documents: Document[];
+
+  beforeEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('5 files, 3 labeler, no split', () => {
+    beforeAll(() => {
+      assignment = {
+        labelers: ['l-one@email.com', 'l-two@email.com', 'l-three@email.com'],
+        reviewers: ['r-one@email.com', 'r-two@email.com'],
+      };
+
+      documents = [
+        { fileName: 'dummy-1' },
+        { fileName: 'dummy-2' },
+        { fileName: 'dummy-3' },
+        { fileName: 'dummy-4' },
+        { fileName: 'dummy-4' },
+      ] as Document[];
+    });
+
+    it('should assign each document to `consensus` number of labeler', () => {
+      const consensusNumber = 2;
+      jest
+        .spyOn(ConfigModule, 'getConfig')
+        .mockName('mockGetConfig')
+        .mockImplementation(() => {
+          return {
+            assignment: {
+              strategy: 'AUTO',
+            },
+            project: {
+              projectSettings: {
+                consensus: consensusNumber,
+              },
+            },
+          } as Config;
+        });
+
+      const documentAssignments = assignAutoDocuments(assignment, documents);
+      expect(checkConsensusReachable(documentAssignments, consensusNumber)).toEqual(true);
+    });
+  });
+
+  describe(`2 files, 3 labelers, consensus is 1, no split`, () => {
+    beforeAll(() => {
+      assignment = {
+        labelers: ['l-one@email.com', 'l-two@email.com', 'l-three@email.com'],
+        reviewers: ['r-one@email.com', 'r-two@email.com'],
+      };
+
+      documents = [{ fileName: 'dummy-1' }, { fileName: 'dummy-2' }] as Document[];
+    });
+
+    it('should give all three labeler at least 1 document', () => {
+      jest
+        .spyOn(ConfigModule, 'getConfig')
+        .mockName('mockGetConfig')
+        .mockImplementation(() => {
+          return {
+            assignment: {
+              strategy: 'AUTO',
+            },
+            project: {
+              projectSettings: {
+                consensus: 1,
+              },
+            },
+          } as Config;
+        });
+      const documentAssignments = assignAutoDocuments(assignment, documents);
+      expect(checkAllLabelerHaveDocuments(documentAssignments, assignment.labelers)).toEqual(true);
+    });
+  });
+
+  describe(`1 file, 5 split, 10 labeler`, () => {
+    beforeAll(() => {
+      assignment = {
+        labelers: [
+          'l-one@email.com',
+          'l-two@email.com',
+          'l-three@email.com',
+          'l-four@email.com',
+          'l-file@email.com',
+          'l-six@email.com',
+          'l-seven@email.com',
+          'l-eight@email.com',
+          'l-nine@email.com',
+          'l-ten@email.com',
+        ],
+        reviewers: ['r-one@email.com', 'r-two@email.com'],
+      };
+
+      documents = [{ fileName: 'dummy-1' }] as Document[];
+    });
+
+    it('should give all labelers at least 1 document', () => {
+      const splitDocumentOption = {
+        number: 5,
+        strategy: SplitDocumentStrategy.BY_PARTS,
+      };
+      jest
+        .spyOn(ConfigModule, 'getConfig')
+        .mockName('mockGetConfig')
+        .mockImplementation(() => {
+          return {
+            assignment: {
+              strategy: 'AUTO',
+            },
+            project: {
+              splitDocumentOption: splitDocumentOption,
+              projectSettings: {
+                consensus: 1,
+              },
+            },
+          } as Config;
+        });
+      const documentAssignments = assignAutoDocuments(assignment, documents);
+      expect(checkAllLabelerHaveDocuments(documentAssignments, assignment.labelers)).toEqual(true);
+      expect(documentsToHaveBeenSplit(documentAssignments, documents, splitDocumentOption)).toEqual(true);
+    });
+  });
+});
+
+function checkConsensusReachable(documentAssignments: DocumentAssignment[], minimumNumber = 0) {
+  const documentMap = new Map<string, number>();
+  documentAssignments.forEach((assignment) => {
+    if (assignment && assignment.documents)
+      assignment.documents.forEach((doc) => {
+        const key = doc.fileName + doc.part;
+        const count = documentMap.get(key) ?? 0;
+        documentMap.set(key, count + 1);
+      });
+  });
+
+  for (const [key, value] of documentMap) {
+    if (value < minimumNumber) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function checkAllLabelerHaveDocuments(documentAssignments: DocumentAssignment[], labelers: string[]) {
+  const labelerMap = new Map<string, number>();
+  labelers.forEach((labeler) => labelerMap.set(labeler, 0));
+
+  for (const documentAssignment of documentAssignments) {
+    const key = documentAssignment.email as string;
+    const currentNumber = labelerMap.get(key) ?? 0;
+    labelerMap.set(key, currentNumber + 1);
+  }
+
+  for (const [_email, countAssigned] of labelerMap) {
+    if (countAssigned < 1) return false;
+  }
+  return true;
+}
+
+function documentsToHaveBeenSplit(
+  documentAssignments: DocumentAssignment[],
+  documents: Document[],
+  splitDocumentOption: Config['project']['splitDocumentOption'],
+) {
+  const splitCount = splitDocumentOption?.number ?? 0;
+  const documentMap = new Map<string, number>();
+  documents.forEach((doc) => documentMap.set(doc.fileName, 0));
+
+  for (const documentAssignment of documentAssignments) {
+    if (documentAssignment.documents) {
+      for (const document of documentAssignment.documents) {
+        const maximumPartNumber = documentMap.get(document.fileName) ?? 0;
+        if (maximumPartNumber < document.part) {
+          documentMap.set(document.fileName, document.part);
+        }
+      }
+    }
+  }
+
+  for (const [_key, value] of documentMap) {
+    if (value + 1 < splitCount) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/src/assignment/assign-auto-documents.ts
+++ b/src/assignment/assign-auto-documents.ts
@@ -1,0 +1,86 @@
+import { getConfig } from '../config/config';
+import { Document } from '../documents/interfaces';
+import { getLogger } from '../logger';
+import { getDocumentsWithPart } from './get-documents-with-part';
+import { getRole } from './get-role';
+import { AssignmentConfig, DocumentAssignment } from './interfaces';
+
+export function assignAutoDocuments(assignmentPool: AssignmentConfig, documents: Document[]): DocumentAssignment[] {
+  const allDocuments = getDocumentsWithPart(documents);
+
+  const members: Record<string, { isLabeler: boolean; isReviewer: boolean }> = {};
+  assignmentPool.labelers.forEach((labeler) => {
+    members[labeler] = { isLabeler: true, isReviewer: false };
+  });
+  assignmentPool.reviewers.forEach((reviewer) => {
+    members[reviewer] = { isLabeler: false || members[reviewer]?.isLabeler, isReviewer: true };
+  });
+
+  const consensus = getConfig()?.project?.projectSettings?.consensus ?? 1;
+
+  const labelerAssignmentMap = new Map<string, Array<{ fileName: string; part: number }>>();
+  const labelerEmails: string[] = [];
+  const reviewerEmails: string[] = [];
+  Object.entries(members).forEach(([email, { isLabeler, isReviewer }]) => {
+    if (isLabeler) {
+      // labeler and labeler_and_reviewer can be assigned documents
+      labelerAssignmentMap.set(email, []);
+      labelerEmails.push(email);
+    } else if (isReviewer) {
+      // reviewers does not need to be assigned - they can access all
+      reviewerEmails.push(email);
+    }
+  });
+
+  if (consensus > labelerEmails.length) {
+    getLogger().error('Consensus lower than number of labelers');
+    throw new Error('Consensus should be smaller or equal to number of labelers');
+  }
+
+  let labelerIndex = 0;
+  for (let index = 0; index < allDocuments.length; index++) {
+    const document = allDocuments[index];
+
+    let numberOfAssignments = 0;
+    while (numberOfAssignments < consensus) {
+      const currentLabeler = labelerEmails[labelerIndex];
+      const assignedDocs = labelerAssignmentMap.get(currentLabeler);
+      labelerAssignmentMap.set(currentLabeler, [
+        ...assignedDocs!,
+        { fileName: document.fileName, part: document.part },
+      ]);
+      numberOfAssignments += 1;
+      labelerIndex = (labelerIndex + 1) % labelerEmails.length;
+    }
+  }
+
+  const unassignedLabelers: string[] = [];
+  labelerAssignmentMap.forEach((value, email) => {
+    if (value.length === 0) {
+      unassignedLabelers.push(email);
+    }
+  });
+
+  // handle case when labeler.length > file.length
+  let documentIndex = 0;
+  unassignedLabelers.forEach((email) => {
+    const document = allDocuments[documentIndex];
+    labelerAssignmentMap.set(email, [{ fileName: document.fileName, part: document.part }]);
+    documentIndex = (documentIndex + 1) % allDocuments.length;
+  });
+
+  const retval: DocumentAssignment[] = [];
+  labelerAssignmentMap.forEach((value, key) => {
+    retval.push({ email: key, documents: value, role: getRoleFromEmail(key, members) });
+  });
+  reviewerEmails.forEach((email) => {
+    retval.push({ email, role: getRoleFromEmail(email, members) });
+  });
+
+  return retval;
+}
+
+function getRoleFromEmail(email: string, members: Record<string, { isLabeler: boolean; isReviewer: boolean }>) {
+  const member = Object.entries(members).find((p) => p[0] === email)!;
+  return getRole(member[1].isLabeler, member[1].isReviewer);
+}

--- a/src/assignment/get-document-assignment.ts
+++ b/src/assignment/get-document-assignment.ts
@@ -8,11 +8,11 @@ import { getLogger } from '../logger';
 export function getDocumentAssignment(assignees: AssignmentConfig, documents: Document[]) {
   const assignmentStrategy = getConfig()?.assignment?.strategy;
   if (!assignmentStrategy) {
-    getLogger().info('no assignment strategy specified, assign all documents to all labelers...')
-    return assignAllDocuments(assignees, documents)
-  };
+    getLogger().info('no assignment strategy specified, assign all documents to all labelers...');
+    return assignAllDocuments(assignees, documents);
+  }
 
-  getLogger().info(`${assignmentStrategy} assignment strategy specified.`)
+  getLogger().info(`${assignmentStrategy} assignment strategy specified.`);
   if (assignmentStrategy === 'ALL') return assignAllDocuments(assignees, documents);
   else if (assignmentStrategy === 'AUTO') return assignAutoDocuments(assignees, documents);
 

--- a/src/assignment/get-document-assignment.ts
+++ b/src/assignment/get-document-assignment.ts
@@ -1,0 +1,20 @@
+import { assignAllDocuments } from './assign-all-documents';
+import { getConfig } from '../config/config';
+import { assignAutoDocuments } from './assign-auto-documents';
+import { AssignmentConfig } from './interfaces';
+import { Document } from '../documents/interfaces';
+import { getLogger } from '../logger';
+
+export function getDocumentAssignment(assignees: AssignmentConfig, documents: Document[]) {
+  const assignmentStrategy = getConfig()?.assignment?.strategy;
+  if (!assignmentStrategy) {
+    getLogger().info('no assignment strategy specified, assign all documents to all labelers...')
+    return assignAllDocuments(assignees, documents)
+  };
+
+  getLogger().info(`${assignmentStrategy} assignment strategy specified.`)
+  if (assignmentStrategy === 'ALL') return assignAllDocuments(assignees, documents);
+  else if (assignmentStrategy === 'AUTO') return assignAutoDocuments(assignees, documents);
+
+  throw new Error(`Unsupported assignment strategy ${assignmentStrategy}`);
+}

--- a/src/assignment/get-documents-with-part.spec.ts
+++ b/src/assignment/get-documents-with-part.spec.ts
@@ -1,0 +1,38 @@
+import * as ConfigModule from '../config/config';
+import { Config, SplitDocumentStrategy } from '../config/interfaces';
+import { Document } from '../documents/interfaces';
+import { getDocumentsWithPart } from './get-documents-with-part';
+
+describe(getDocumentsWithPart.name, () => {
+  let documents: Document[];
+  beforeAll(() => {
+    documents = [{ fileName: 'dummy-1' }, { fileName: 'dummy-2' }] as Document[];
+  });
+
+  describe(`${SplitDocumentStrategy.BY_PARTS}`, () => {
+    it('should split documents with 0 ... n-1 part', () => {
+      const N_PARTS = 5;
+      jest.spyOn(ConfigModule, 'getConfig').mockImplementation(() => {
+        return {
+          project: {
+            splitDocumentOption: {
+              strategy: SplitDocumentStrategy.BY_PARTS,
+              number: N_PARTS,
+            },
+          },
+        } as Config;
+      });
+
+      const actual = getDocumentsWithPart(documents);
+      expect(actual.length).toEqual(documents.length * N_PARTS);
+      expect(checkDocumentWithParts(actual, N_PARTS)).toBeTruthy();
+    });
+  });
+});
+
+function checkDocumentWithParts(documentsWithPart: Array<{ part: number; fileName: string }>, N_PARTS: number) {
+  for (const document of documentsWithPart) {
+    if (document.part > N_PARTS) return false;
+  }
+  return true;
+}

--- a/src/assignment/get-documents-with-part.ts
+++ b/src/assignment/get-documents-with-part.ts
@@ -1,0 +1,43 @@
+import { getConfig } from '../config/config';
+import { Config, SplitDocumentStrategy } from '../config/interfaces';
+import { Document } from '../documents/interfaces';
+import { getLogger } from '../logger';
+
+export function getDocumentsWithPart(documents: Document[]) {
+  const splitDocumentOption = getConfig()?.project?.splitDocumentOption;
+
+  const documentsWithPartInformation = documents.map((document) => ({
+    fileName: document.fileName,
+    part: 0,
+  }));
+
+  if (isSplitDocumentOptionValid(splitDocumentOption)) {
+    getLogger().info('SplitDocumentOption detected, assigning split files...', { splitDocumentOption });
+    const numberOfParts = splitDocumentOption?.number as number;
+    for (let index = 1; index < numberOfParts; index++) {
+      for (const document of documents) {
+        documentsWithPartInformation.push({ fileName: document.fileName, part: index });
+      }
+    }
+  } else {
+    getLogger().info('invalid / no SplitDocumentOption detected, assigning document as-is', { splitDocumentOption });
+  }
+
+  documentsWithPartInformation.sort((doc1, doc2) => {
+    const stringComparisonResult = doc1.fileName.localeCompare(doc2.fileName);
+    if (stringComparisonResult === 0) {
+      return doc1.part - doc2.part;
+    }
+    return stringComparisonResult;
+  });
+
+  return documentsWithPartInformation;
+}
+
+function isSplitDocumentOptionValid(splitDocumentOption: Config['project']['splitDocumentOption'] | undefined) {
+  return (
+    Boolean(splitDocumentOption) &&
+    splitDocumentOption?.strategy === SplitDocumentStrategy.BY_PARTS &&
+    splitDocumentOption?.number > 1
+  );
+}

--- a/src/config/interfaces.ts
+++ b/src/config/interfaces.ts
@@ -7,6 +7,13 @@ export enum StorageSources {
   AMAZONS3 = 's3',
 }
 
+export enum SplitDocumentStrategy{
+  /**
+   * @description Split each document into n equal parts, basedd on the `number` value
+   */
+  BY_PARTS = "BY_PARTS"
+}
+
 export interface Config {
   datasaur: {
     /**
@@ -128,6 +135,14 @@ export interface Config {
          */
         name: string;
       }>;
+    };
+
+    /**
+     * @description Optional. Configuration for splitting documents in a project
+     */
+    splitDocumentOption?: {
+      strategy: SplitDocumentStrategy;
+      number: number;
     };
   };
 }

--- a/src/config/interfaces.ts
+++ b/src/config/interfaces.ts
@@ -7,11 +7,12 @@ export enum StorageSources {
   AMAZONS3 = 's3',
 }
 
-export enum SplitDocumentStrategy{
+export enum SplitDocumentStrategy {
   /**
-   * @description Split each document into n equal parts, basedd on the `number` value
+   * @description Split each document into n equal parts, based on the `number` value
    */
-  BY_PARTS = "BY_PARTS"
+  BY_PARTS = 'BY_PARTS',
+  DONT_SPLIT = 'DONT_SPLIT',
 }
 
 export interface Config {
@@ -196,11 +197,11 @@ export interface AssignmentConfig extends WithStorage {
   path: string;
 
   /**
-   * @description document assignment strategy. 
+   * @description document assignment strategy.
    * ALL -> all documents will be assigned to all labelers
-   * AUTO -> round-robin assignment for labelers 
+   * AUTO -> round-robin assignment for labelers
    */
-  strategy: 'ALL' | 'AUTO'
+  strategy: 'ALL' | 'AUTO';
 }
 
 export interface ExportConfig extends WithStorage {

--- a/src/config/interfaces.ts
+++ b/src/config/interfaces.ts
@@ -194,6 +194,13 @@ export interface AssignmentConfig extends WithStorage {
    * @description local or remote path to assignment file
    */
   path: string;
+
+  /**
+   * @description document assignment strategy. 
+   * ALL -> all documents will be assigned to all labelers
+   * AUTO -> round-robin assignment for labelers 
+   */
+  strategy: 'ALL' | 'AUTO'
 }
 
 export interface ExportConfig extends WithStorage {

--- a/src/config/schema/assignment-schema-validator.ts
+++ b/src/config/schema/assignment-schema-validator.ts
@@ -10,6 +10,7 @@ const AssignmentSchema: JSONSchemaType<AssignmentConfig> = {
   properties: {
     source: { type: 'string' },
     path: { type: 'string' },
+    strategy: { enum: ['ALL', 'AUTO'], default: 'ALL', type: 'string' },
     bucketName: { type: 'string', nullable: true }, // nullable when local
   },
   required: ['path', 'source'],

--- a/src/datasaur/create-project.ts
+++ b/src/datasaur/create-project.ts
@@ -64,7 +64,7 @@ export async function createProject(
       labelerExtensions: EXTENSIONS[settings.documentSettings.kind].LABELER,
       reviewerExtensions: EXTENSIONS[settings.documentSettings.kind].REVIEWER,
       labelSetIDs,
-      splitDocumentOption: settings.splitDocumentOption
+      splitDocumentOption: settings.splitDocumentOption,
     },
   };
 

--- a/src/datasaur/create-project.ts
+++ b/src/datasaur/create-project.ts
@@ -64,6 +64,7 @@ export async function createProject(
       labelerExtensions: EXTENSIONS[settings.documentSettings.kind].LABELER,
       reviewerExtensions: EXTENSIONS[settings.documentSettings.kind].REVIEWER,
       labelSetIDs,
+      splitDocumentOption: settings.splitDocumentOption
     },
   };
 

--- a/src/handlers/create-projects.handler.ts
+++ b/src/handlers/create-projects.handler.ts
@@ -1,7 +1,7 @@
 import { writeFileSync } from 'fs';
 import { resolve } from 'path';
-import { assignAllDocuments } from '../assignment/assign-all-documents';
 import { getAssignmentConfig } from '../assignment/get-assignment-config';
+import { getDocumentAssignment } from '../assignment/get-document-assignment';
 import { DocumentAssignment } from '../assignment/interfaces';
 import { getConfig, setConfigByJSONFile } from '../config/config';
 import { StorageSources } from '../config/interfaces';
@@ -107,7 +107,7 @@ export async function handleCreateProjects(configFile: string, options) {
       const newProjectConfiguration: ProjectConfiguration = {
         projectName: projectDetails.name,
         documents,
-        documentAssignments: assignAllDocuments(assignees, documents),
+        documentAssignments: getDocumentAssignment(assignees, documents),
         projectConfig: updatedProjectConfig,
       };
 


### PR DESCRIPTION
DONE
- add splitDocumentOption in config interface & createProject function
- adjust readme

---

TODO
- add `assignmentStrategy` to config, accepting `auto` OR `all` (if not present, defaults to `all`)
