### PR TITLE
#12106 Support distribution by project

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -472,15 +472,15 @@ Robosaur **does not** support providing documents through PCW payload. The `docu
 ```json
 {
   ...
-  // "assignment": {
-  //    DO NOT provide this option
-  // }
+  "assignment": { // use this only if you want to distribute by projects
+    ...
+  },
   "project": {
     ...
     "pcwPayloadSource": {
       "source": "inline",
     },
-    "pcwAssignmentStrategy": "AUTO",
+    "pcwAssignmentStrategy": "AUTO", // remove this if you want to distribute by projects
     "pcwPayload": {
       ...
       "documentAssignments": [

--- a/src/assignment/get-assignment-config.ts
+++ b/src/assignment/get-assignment-config.ts
@@ -6,6 +6,7 @@ import { validateAssignment } from './validate-assignments';
 export async function getAssignmentConfig(): Promise<AssignmentConfig> {
   getLogger().info('parsing assignments');
   const assignees = await parseAssignment();
+  getLogger().info('validating project assignment...');
   await validateAssignment(assignees);
   return assignees;
 }

--- a/src/assignment/get-project-assignment.ts
+++ b/src/assignment/get-project-assignment.ts
@@ -1,0 +1,15 @@
+import { assignAllDocuments } from './assign-all-documents';
+import { getConfig } from '../config/config';
+import { AssignmentConfig } from './interfaces';
+import { Document } from '../documents/interfaces';
+
+export function getProjectAssignment(assignees: AssignmentConfig, documents: Document[], selectedLabelers: string[]) {
+  let assignmentStrategy;
+  if (assignees.useTeamMemberId) {
+    assignmentStrategy = getConfig()?.create?.pcwAssignmentStrategy;
+  } else {
+    assignmentStrategy = getConfig()?.create?.assignment?.strategy;
+    assignees.labelers = selectedLabelers;
+  }
+  return assignAllDocuments(assignees, documents);
+}

--- a/src/config/interfaces.ts
+++ b/src/config/interfaces.ts
@@ -273,6 +273,7 @@ export interface AssignmentConfig extends WithStorage {
    * @description local or remote path to assignment file
    */
   path: string;
+  by: 'PROJECT' | 'DOCUMENT';
 
   /**
    * @description document assignment strategy.

--- a/src/config/schema/assignment-schema-validator.ts
+++ b/src/config/schema/assignment-schema-validator.ts
@@ -10,6 +10,7 @@ const AssignmentSchema: JSONSchemaType<AssignmentConfig> = {
   properties: {
     source: { type: 'string' },
     path: { type: 'string' },
+    by: { enum: ['PROJECT', 'DOCUMENT'], default: 'DOCUMENT', type: 'string' },
     strategy: { enum: ['ALL', 'AUTO'], default: 'ALL', type: 'string' },
     bucketName: { type: 'string', nullable: true }, // nullable when local
   },

--- a/src/handlers/create-projects.handler.ts
+++ b/src/handlers/create-projects.handler.ts
@@ -2,9 +2,10 @@ import { writeFileSync } from 'fs';
 import { resolve } from 'path';
 import { getAssignmentConfig } from '../assignment/get-assignment-config';
 import { getDocumentAssignment } from '../assignment/get-document-assignment';
+import { getProjectAssignment } from '../assignment/get-project-assignment';
 import { DocumentAssignment } from '../assignment/interfaces';
 import { getConfig, setConfigByJSONFile } from '../config/config';
-import { StorageSources } from '../config/interfaces';
+import { CreateConfig, FilesConfig, StorageSources } from '../config/interfaces';
 import { getProjectCreationValidators } from '../config/schema/validator';
 import { JobStatus } from '../datasaur/get-jobs';
 import { getLocalDocuments } from '../documents/get-local-documents';
@@ -15,15 +16,24 @@ import { setConfigFromPcw } from '../transformer/pcw-transformer/setConfigFromPc
 import { getLabelSetsFromDirectory } from '../utils/labelset';
 import { pollJobsUntilCompleted } from '../utils/polling.helper';
 import { getQuestionSetFromFile } from '../utils/questionset';
+import { readJSONFile } from '../utils/readJSONFile';
 import { getState } from '../utils/states/getStates';
+import { ScriptState } from '../utils/states/script-state';
 import { ScriptAction } from './constants';
 import { handleCreateProject } from './create-project.handler';
 import { doCreateProjectAndUpdateState, getProjectNamesFromFolderNames } from './creation/helper';
+
+interface ProjectCreationOption {
+  dryRun: boolean;
+  usePcw: boolean;
+  withoutPcw: boolean;
+}
 
 interface ProjectConfiguration {
   projectName: string;
   documents: Array<RemoteDocument | LocalDocument>;
   documentAssignments: Array<DocumentAssignment>;
+  job?: { id: string };
 
   /**
    * @description taken from getConfig().project
@@ -34,15 +44,36 @@ interface ProjectConfiguration {
 const LIMIT_RETRY = 3;
 const PROJECT_BEFORE_SAVE = 5;
 
-export async function handleCreateProjects(configFile: string, options) {
+export async function handleCreateProjects(configFile: string, options: ProjectCreationOption) {
   const { dryRun, withoutPcw, usePcw } = options;
   const cwd = process.cwd();
+
+  await setProjectCreationConfig(cwd, configFile, usePcw, withoutPcw);
+
+  const scriptState = await getState();
+  await scriptState.updateInProgressProjectCreationStates();
+
+  const createConfig = getConfig().create;
+
+  const projectsToBeCreated = await getProjectsToBeCreated(createConfig.files, scriptState, dryRun);
+
+  await setLabelSetsOrQuestions(createConfig);
+
+  const results = await submitProjectCreationJob(createConfig, projectsToBeCreated, scriptState, dryRun);
+  await checkProjectCreationJob(results, scriptState, cwd, dryRun);
+}
+
+async function setProjectCreationConfig(cwd: string, configFile: string, usePcw: boolean, withoutPcw: boolean) {
   setConfigByJSONFile(resolve(cwd, configFile), getProjectCreationValidators(), ScriptAction.PROJECT_CREATION);
 
   if (withoutPcw) {
     getLogger().info('withoutPcw is set to true, parsing config...');
   } else if (usePcw) {
     await setConfigFromPcw(getConfig());
+    if (getConfig().create.assignment?.path && !getConfig().create.pcwAssignmentStrategy) {
+      const rawConfig = readJSONFile(resolve(cwd, getConfig().create.assignment!.path));
+      getConfig().create.assignments = rawConfig;
+    }
   }
 
   const documentSource = getConfig().create.files.source;
@@ -53,42 +84,43 @@ export async function handleCreateProjects(configFile: string, options) {
       );
       return handleCreateProject('New Robosaur Project', configFile);
   }
-  const { bucketName, prefix: storagePrefix, source, path } = getConfig().create.files;
+}
 
-  const scriptState = await getState();
-  await scriptState.updateInProgressProjectCreationStates();
-
-  let projectsToCreate: { name: string; fullPath: string }[];
-  projectsToCreate = await getProjectNamesFromFolderNames(source, { bucketName, prefix: storagePrefix, path });
+async function getProjectsToBeCreated(
+  filesConfig: FilesConfig,
+  scriptState: ScriptState,
+  dryRun: boolean,
+): Promise<{ name: string; fullPath: string }[]> {
+  const { source, bucketName, prefix, path } = filesConfig;
 
   // potential improvement: checks documents / file inside each bucket folder
-  projectsToCreate = projectsToCreate.filter((project) => !scriptState.projectNameHasBeenUsed(project.name));
+  const projectsToBeCreated: { name: string; fullPath: string }[] = (
+    await getProjectNamesFromFolderNames(source, { bucketName, prefix, path })
+  ).filter((project) => !scriptState.projectNameHasBeenUsed(project.name));
 
-  if (projectsToCreate.length === 0) {
+  if (projectsToBeCreated.length === 0) {
     getLogger().info('no projects left to create, exiting...');
     if (!dryRun) await scriptState.save();
-    return;
+    return [];
   }
-  getLogger().info(`found ${projectsToCreate.length} projects to create: ${JSON.stringify(projectsToCreate)}`);
+  getLogger().info(`found ${projectsToBeCreated.length} projects to create: ${JSON.stringify(projectsToBeCreated)}`);
+  return projectsToBeCreated;
+}
 
-  const updatedProjectConfig = getConfig().create;
-
-  if (
-    updatedProjectConfig.documentSettings.kind == 'TOKEN_BASED' ||
-    updatedProjectConfig.kinds?.includes('TOKEN_BASED')
-  ) {
-    if (!updatedProjectConfig.labelSets) updatedProjectConfig.labelSets = getLabelSetsFromDirectory(getConfig());
+async function setLabelSetsOrQuestions(createConfig: CreateConfig) {
+  if (createConfig.documentSettings.kind == 'TOKEN_BASED' || createConfig.kinds?.includes('TOKEN_BASED')) {
+    if (!createConfig.labelSets) createConfig.labelSets = getLabelSetsFromDirectory(getConfig());
   } else if (
-    updatedProjectConfig.documentSettings.kind == 'ROW_BASED' ||
-    updatedProjectConfig.documentSettings.kind == 'DOCUMENT_BASED' ||
-    updatedProjectConfig.kinds?.includes('ROW_BASED') ||
-    updatedProjectConfig.kinds?.includes('DOCUMENT_BASED')
+    createConfig.documentSettings.kind == 'ROW_BASED' ||
+    createConfig.documentSettings.kind == 'DOCUMENT_BASED' ||
+    createConfig.kinds?.includes('ROW_BASED') ||
+    createConfig.kinds?.includes('DOCUMENT_BASED')
   ) {
-    if (!updatedProjectConfig.questions) {
-      if (updatedProjectConfig.questionSetFile) {
-        updatedProjectConfig.questions = getQuestionSetFromFile(getConfig());
+    if (!createConfig.questions) {
+      if (createConfig.questionSetFile) {
+        createConfig.questions = getQuestionSetFromFile(getConfig());
       } else {
-        getLogger().warn(`no 'questions' or 'questionSetFile' is configured in ${configFile}`);
+        getLogger().warn(`no 'questions' or 'questionSetFile' is configured in the config file`);
         if (getConfig().create.labelSetDirectory) {
           getLogger().warn(
             `Robosaur does not support ROW_BASED project creation using TOKEN_BASED csv labelsets. Please refer to our JSON documentation on how to structure ROW_BASED questions`,
@@ -98,27 +130,42 @@ export async function handleCreateProjects(configFile: string, options) {
       }
     }
   }
+}
 
-  getLogger().info('validating project assignment...');
+async function submitProjectCreationJob(
+  createConfig: CreateConfig,
+  projectsToBeCreated: { name: string; fullPath: string }[],
+  scriptState: ScriptState,
+  dryRun: boolean,
+): Promise<ProjectConfiguration[]> {
   const assignees = await getAssignmentConfig();
 
   let results: any[] = [];
   let projectCounter = 0;
-  for (const projectDetails of projectsToCreate) {
+  const labelers = getConfig().create.assignments?.labelers || [];
+  let currentLabelerIndex = 0;
+  for (const projectDetails of projectsToBeCreated) {
     let counterRetry = 0;
     while (counterRetry < LIMIT_RETRY) {
       getLogger().info(`creating project ${projectDetails.name}...`);
-      getLogger().info(`retrieving documents from ${source}...`);
+      getLogger().info(`retrieving documents from ${createConfig.files.source}...`);
       const documents =
-        source === StorageSources.LOCAL
+        createConfig.files.source === StorageSources.LOCAL
           ? getLocalDocuments(projectDetails.fullPath)
-          : await getObjectStorageDocuments(bucketName, projectDetails.fullPath);
+          : await getObjectStorageDocuments(createConfig.files.bucketName, projectDetails.fullPath);
 
       const newProjectConfiguration: ProjectConfiguration = {
         projectName: projectDetails.name,
         documents,
-        documentAssignments: getDocumentAssignment(assignees, documents),
-        projectConfig: updatedProjectConfig,
+        documentAssignments:
+          createConfig.assignment && createConfig.assignment?.by === 'PROJECT'
+            ? getProjectAssignment(
+                assignees,
+                documents,
+                getConfig().create.assignment?.strategy === 'AUTO' ? [labelers[currentLabelerIndex]] : labelers,
+              )
+            : getDocumentAssignment(assignees, documents),
+        projectConfig: createConfig,
       };
 
       if (dryRun) {
@@ -152,8 +199,18 @@ export async function handleCreateProjects(configFile: string, options) {
 
     projectCounter += 1;
     if (projectCounter % PROJECT_BEFORE_SAVE === 0) await scriptState.save();
+    currentLabelerIndex = (currentLabelerIndex + 1) % labelers.length;
   }
 
+  return results;
+}
+
+async function checkProjectCreationJob(
+  results: ProjectConfiguration[],
+  scriptState: ScriptState,
+  cwd: string,
+  dryRun: boolean,
+) {
   if (dryRun) {
     let filepath = resolve(cwd, `dry-run-output-${Date.now()}.json`);
     writeFileSync(filepath, JSON.stringify(results, null, 2));
@@ -162,7 +219,7 @@ export async function handleCreateProjects(configFile: string, options) {
     await scriptState.save();
     getLogger().info(`sending query for ProjectLaunchJob status...`);
 
-    const jobs = await pollJobsUntilCompleted(results.map((r) => r.job.id));
+    const jobs = await pollJobsUntilCompleted(results.map((r) => r.job?.id || ''));
 
     const createFail = jobs.filter((j) => j.status === JobStatus.FAILED);
     const createOK = jobs.filter((j) => j.status === JobStatus.DELIVERED).map((j) => j.id);


### PR DESCRIPTION
### Changes
- Using the same strategies, i.e. `AUTO` and `ALL`, now we also support the distribution for projects. Instead of document distribution, now we can distribute each project and the documents of each project will be distributed by all assigned labelers.
- New attribute `by` on `AssignmentConfig`: `PROJECT` or `DOCUMENT`.
- Refactor `create-projects.handler.ts`.
