### PR TITLE
Re-throw error for proper error bubbling

### DIFF
--- a/src/datasaur/query.ts
+++ b/src/datasaur/query.ts
@@ -25,7 +25,11 @@ export async function query<T = any, V = any>(
         // most likely because the access token is expired so try to re-generate a new access token
         currentClient = undefined;
         client = await getClient();
+      } else {
+        throw error;
       }
+    } else {
+      throw error;
     }
   }
   return client.request<T, V>(document, variables, requestHeaders);


### PR DESCRIPTION
Problem: 
- HTTP error 413 does not appear in Robosaur logs. Robosaur shows ECONNRESET instead, which is confusing
![image](https://user-images.githubusercontent.com/89899945/198546630-20360ce0-fc38-40c7-83f9-dfd1033d6fc5.png)

Cause: 
- Error is swallowed silently while checking for access-token expiry, and Robosaur sends 2 consecutive request instead. This somehow reuses the same connection, and was reset early,

Changes: 
- add else blocks to throw the error if the error is not about access token expiration


Should throw correctly showing the HTML content of 413 page