### PR TITLE
Support new BBOX_BASED project creation

### DIFF
--- a/src/datasaur/constants.ts
+++ b/src/datasaur/constants.ts
@@ -51,4 +51,8 @@ export const EXTENSIONS = {
       ExtensionID.FILE_COLLECTION_EXTENSION_ID,
     ],
   },
+  BBOX_BASED: {
+    LABELER: [],
+    REVIEWER: [],
+  },
 };


### PR DESCRIPTION
Without the new constant, the project creation fails with a relatively opaque error: 

```
{"@fields":{"command":"create-projects","error":"{}","level":"warn","trace-id":"7630f8df-9046-4dbe-b426-eb9b43f19883"},"@message":"error creating <PROJECT NAME>, retrying... Cannot read properties of undefined (reading 'LABELER')","@timestamp":"2022-12-22 09:44:19"}
```


TODO: 
1. map and send bboxLabelSets in the payload