### PR TITLE
Fix Missing HealthCheck Log

### DIFF
--- a/src/handlers/health-check.handler.ts
+++ b/src/handlers/health-check.handler.ts
@@ -1,5 +1,4 @@
-import { existsSync, read, writeFileSync } from 'fs';
-import { writeFile, readFile, access } from 'fs/promises';
+import { access, readFile, writeFile } from 'fs/promises';
 import { Health, healthPath, HEALTH_STATUS } from '../datasaur/rex/interface';
 import { createSimpleHandlerContext } from '../execution';
 import { getLogger } from '../logger';

--- a/src/handlers/health-check.handler.ts
+++ b/src/handlers/health-check.handler.ts
@@ -1,17 +1,20 @@
-import { existsSync, readFileSync, writeFileSync } from 'fs';
+import { existsSync, read, writeFileSync } from 'fs';
+import { writeFile, readFile, access } from 'fs/promises';
 import { Health, healthPath, HEALTH_STATUS } from '../datasaur/rex/interface';
 import { createSimpleHandlerContext } from '../execution';
 import { getLogger } from '../logger';
 
 export const healthCheck = createSimpleHandlerContext('health-check', _healthCheck);
 
-function _healthCheck() {
-  if (!existsSync(healthPath)) {
+async function _healthCheck() {
+  try {
+    await access(healthPath);
+  } catch (_err) {
     getLogger().error('File not exist, exiting with code 1');
     process.exit(1);
   }
 
-  const readResult = readFileSync(healthPath).toString('utf-8');
+  const readResult = await readFile(healthPath, { encoding: 'utf-8' });
   let healthObject: Health;
   try {
     healthObject = JSON.parse(readResult);
@@ -26,7 +29,7 @@ function _healthCheck() {
   }
 
   healthObject.timestamp = new Date();
-  writeFileSync(healthPath, Buffer.from(JSON.stringify(healthObject), 'utf-8'));
+  await writeFile(healthPath, Buffer.from(JSON.stringify(healthObject), 'utf-8'));
 
   getLogger().info('Consumer healthy, exiting with code 0');
   process.exit(0);


### PR DESCRIPTION
## Problems
somehow when using sync function from node std lib, the logger doesn't works.

## Changes
- update healthcheck logic to use `fs/promises`

Here's my local screenshot when using `fs/promises`
![image](https://user-images.githubusercontent.com/102159897/216509368-a25a65f1-3ad9-41eb-bbf2-6ce339ce5bd4.png)
