### PR TITLE
#16639 restart script

### DIFF
--- a/on-premise/upgrade-robosaur.sh
+++ b/on-premise/upgrade-robosaur.sh
@@ -11,6 +11,7 @@
 
 currentVersion=$1
 newVersion=$2
+currentDirectory=/opt
 
 cd datasaur-robosaur-$currentVersion
 ./down.sh
@@ -20,6 +21,10 @@ mkdir datasaur-robosaur-$newVersion && tar -zvxf datasaur-robosaur-$newVersion.t
 cp datasaur-robosaur-$currentVersion-old/robosaur.env datasaur-robosaur-$newVersion/
 cp -r datasaur-robosaur-$currentVersion-old/docker-config datasaur-robosaur-$newVersion/
 cd datasaur-robosaur-$newVersion
-./add-channel.sh 15
-./add-channel.sh 16
+./add-channel.sh 15 1000 1000
+./add-channel.sh 16 1000 1000
 ./upgrade.sh
+
+# Use sed to modify restart_instruction_letter.sh
+scriptFile="$currentDirectory/restart_instruction_letter.sh"
+sed -i "s|$currentDirectory/datasaur-robosaur-$currentVersion|$currentDirectory/datasaur-robosaur-$newVersion|g" "$scriptFile"

--- a/src/datasaur/rex/cancel-state.ts
+++ b/src/datasaur/rex/cancel-state.ts
@@ -2,7 +2,7 @@ export enum CancelState {
   UPDATE_IN_PROGRESS = 'Document id {id} stopped after update savekeeping status to In Progress',
   DOCUMENT_RECOGNITION = 'Document id {id} stopped after document-recognition process',
   PROJECT_CREATION = 'Document id {id} stopped after project creation',
-  PROJECT_EXPORT = 'Document id {id} stopped after project export',
+  PROJECT_EXPORT = 'Document id {id} stopped after field extraction and project export',
   TEXT_EXTRACTION = 'Document id {id} stopped after text-extraction process at page {page}',
   FIELD_EXTRACTION = 'Document id {id} stopped after field-extraction process',
   POST_PROCESSING = 'Document id {id} stopped after post-processing process',

--- a/src/export/save-to-database.ts
+++ b/src/export/save-to-database.ts
@@ -55,8 +55,6 @@ export async function saveExportResultsToDatabase(teamId: number, id: number) {
       const [_teamId, ...restFileName] = filenameWithExtension;
       const filename = restFileName.join('_');
 
-      await checkRecordStatus(id, CancelState.FIELD_EXTRACTION);
-
       getLogger().info(`post processing document_data of ${file}...`);
       documentData[filename] = await postProcessDocumentData(json.document_data);
       readingResult[filename] = json.reading_result;


### PR DESCRIPTION
#### Changes
1. Implementation of restart script (saved in ocrosaurus) need additional command to change the version of robosaur inside restart script through `upgrade-robosaur.sh`.
2. Remove checkRecordStatus on looping before start postprocessing due to not appropriate message.
3. Change `PROJECT_EXPORT` cancel in progress message to indicate the OCR process is stopped after field extraction and project export.